### PR TITLE
Update glueTableToFields to report decimal columns

### DIFF
--- a/src/glue.js
+++ b/src/glue.js
@@ -17,7 +17,8 @@ function glueTableToFields(table) {
   columns.forEach(function (column) {
     // Set fields based on data type
     var field;
-    switch (column.Type.toLowerCase()) {
+    var column_type = column.Type.toLowerCase().indexOf('decimal') > -1 ? 'decimal' : column.Type.toLowerCase()
+    switch (column_type) {
       case 'boolean':
         field = fields.newDimension()
           .setId(column.Name)


### PR DESCRIPTION
Wasn't properly reporting columns of decimal type from Athena to Data Studio.

the `column.Type` value looks like this for decimals: `decimal(10,2)` so the case statement wasn't catching them.